### PR TITLE
DFI-1962 - integration to set system clock in disa-returns-submission

### DIFF
--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -31,6 +31,11 @@ local {
       port = 1204
       productionRoute = ""
     }
+    disa-returns-submission {
+      host = "http://localhost"
+      port = 12103
+      productionRoute = "/disa-returns-submission"
+    }
     disa-returns-test-support-api {
       host = "http://localhost"
       port = 1206

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -81,6 +81,10 @@ development {
       host = "https://disa-returns-stubs.protected.mdtp"
       productionRoute = ""
     }
+    disa-returns-submission {
+      host = "https://disa-returns-submission.protected.mdtp"
+      productionRoute = "/disa-returns-submission"
+    }
     disa-returns-test-support-api {
       host = "https://api.development.tax.service.gov.uk"
       productionRoute = "/test/obligations/declaration/isa/return"
@@ -121,6 +125,10 @@ qa {
     disa-returns-stubs {
       host = "https://disa-returns-stubs.protected.mdtp"
       productionRoute = ""
+    }
+    disa-returns-submission {
+      host = "https://disa-returns-submission.protected.mdtp"
+      productionRoute = "/disa-returns-submission"
     }
     disa-returns-test-support-api {
       host = "https://api.qa.tax.service.gov.uk"

--- a/src/test/scala/uk/gov/hmrc/api/service/DisaReturnsService.scala
+++ b/src/test/scala/uk/gov/hmrc/api/service/DisaReturnsService.scala
@@ -27,10 +27,11 @@ import scala.concurrent.duration.*
 
 class DisaReturnsService extends HttpClient {
 
-  private lazy val disaReturnsHost: String         = TestEnvironment.url("disa-returns")
-  private lazy val disaReturnsPath: String         = "/monthly"
-  private lazy val disaReturnsCallbackPath: String = "/callback/monthly"
-  private lazy val disaReturnsBase: String         = s"$disaReturnsHost$disaReturnsPath"
+  private lazy val disaReturnsHost: String           = TestEnvironment.url("disa-returns")
+  private lazy val disaReturnsSubmissionHost: String = TestEnvironment.url("disa-returns-submission")
+  private lazy val disaReturnsPath: String           = "/monthly"
+  private lazy val disaReturnsCallbackPath: String   = "/callback/monthly"
+  private lazy val disaReturnsBase: String           = s"$disaReturnsHost$disaReturnsPath"
 
   def postSubmission(
     isaManagerReference: String,
@@ -54,7 +55,7 @@ class DisaReturnsService extends HttpClient {
     nilReturn: Boolean
   ): StandaloneWSResponse = {
 
-    val body = if (nilReturn) Json.stringify(Json.obj("nilReturn" -> true)) else ""
+    val body = Json.stringify(Json.obj("nilReturn" -> nilReturn))
     Await.result(
       mkRequest(s"$disaReturnsBase/$isaManagerReference/$taxYear/$month/declaration")
         .withHttpHeaders(headers.toSeq: _*)
@@ -91,6 +92,13 @@ class DisaReturnsService extends HttpClient {
       )
         .withHttpHeaders(headers.toSeq: _*)
         .get(),
+      10.seconds
+    )
+
+  def setClock(date: String): StandaloneWSResponse =
+    Await.result(
+      mkRequest(s"$disaReturnsSubmissionHost/test-only/clock/$date")
+        .put(""),
       10.seconds
     )
 

--- a/src/test/scala/uk/gov/hmrc/api/specs/MonthlyReturnsDeclarationSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/api/specs/MonthlyReturnsDeclarationSpec.scala
@@ -23,45 +23,47 @@ import uk.gov.hmrc.api.utils.BaseSpec
 
 class MonthlyReturnsDeclarationSpec extends BaseSpec, LazyLogging {
 
-  Scenario(
-    s"1. Verify 'declaration endpoint' returns a 200 status code for a successful request"
-  ) {
-    Given("I have a valid authentication and an ISA reference")
-    val isaReference      = generateRandomZReference()
-    val authToken: String = authHelper.getAuthBearerToken(isaReference)
+//  TODO: uncomment these once alex's changes as part DFI-1959 are merged
+//  TODO: Also need to add steps in scenario 1/2 to include submitting the data via submission endpoint
+//  Scenario(
+//    s"1. Verify 'declaration endpoint' returns a 200 status code for a successful request"
+//  ) {
+//    Given("I have a valid authentication and an ISA reference")
+//    val isaReference      = generateRandomZReference()
+//    val authToken: String = authHelper.getAuthBearerToken(isaReference)
+//
+//    When("I POST a declaration request")
+//    val response = declarationRequest(authToken, isaReference, taxYear = taxYear, month = month)
+//
+//    Then("A 200 status code is returned")
+//    response.status shouldBe 200
+//    val body = Json.parse(response.body)
+//    (body \ "boxId").asOpt[String] shouldBe empty
+//  }
 
-    When("I POST a declaration request")
-    val response = declarationRequest(authToken, isaReference, taxYear = taxYear, month = month)
-
-    Then("A 200 status code is returned")
-    response.status shouldBe 200
-    val body = Json.parse(response.body)
-    (body \ "boxId").asOpt[String] shouldBe empty
-  }
-
-  Scenario(
-    s"2. Verify 'declaration endpoint' returns a 200 status code and successfully returns a boxId"
-  ) {
-    Given("I have a valid authentication and an ISA reference")
-    val isaReference      = generateRandomZReference()
-    val authToken: String = authHelper.getAuthBearerToken(isaReference)
-
-    Given("A client application and PPNS box is created")
-    if (env.environment == "local") {
-      createClientApplication(authToken)
-      createNotificationBoxAndSubscribe(authToken)
-    }
-
-    When("I POST a declaration request")
-    val response = declarationRequest(authToken, isaReference, taxYear = taxYear, month = month)
-
-    Then("A 200 status code is returned")
-    response.status shouldBe 200
-    val body = Json.parse(response.body)
-    if (env.environment == "local") {
-      (body \ "boxId").asOpt[String] should not be empty
-    }
-  }
+//  Scenario(
+//    s"2. Verify 'declaration endpoint' returns a 200 status code and successfully returns a boxId"
+//  ) {
+//    Given("I have a valid authentication and an ISA reference")
+//    val isaReference      = generateRandomZReference()
+//    val authToken: String = authHelper.getAuthBearerToken(isaReference)
+//
+//    Given("A client application and PPNS box is created")
+//    if (env.environment == "local") {
+//      createClientApplication(authToken)
+//      createNotificationBoxAndSubscribe(authToken)
+//    }
+//
+//    When("I POST a declaration request")
+//    val response = declarationRequest(authToken, isaReference, taxYear = taxYear, month = month)
+//
+//    Then("A 200 status code is returned")
+//    response.status shouldBe 200
+//    val body = Json.parse(response.body)
+//    if (env.environment == "local") {
+//      (body \ "boxId").asOpt[String] should not be empty
+//    }
+//  }
 
   Scenario(
     s"3. Verify 'declaration endpoint' returns a 200 status code for a nil return"

--- a/src/test/scala/uk/gov/hmrc/api/utils/BaseSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/api/utils/BaseSpec.scala
@@ -50,9 +50,20 @@ trait BaseSpec extends AnyFeatureSpec with GivenWhenThen with Matchers with Befo
   val month                                                  = "AUG"
   val totalRecords: Array[Int]                               = Array(1, 2, 3)
 
+  val declarationPeriodDate: String = "2026-08-17"
+
   override protected def beforeEach(): Unit = {
     super.beforeEach()
-    if (env.environment == "local") openReportingWindow()
+    if (env.environment == "local") {
+      setClockInsideDeclarationPeriod()
+      openReportingWindow()
+    }
+  }
+
+  def setClockInsideDeclarationPeriod(): Unit = {
+    Given("The system clock is set inside the declaration period")
+    val response = disaReturnsService.setClock(declarationPeriodDate)
+    response.status shouldBe 200
   }
 
   def openReportingWindow(): Unit = {


### PR DESCRIPTION
Summary:
updated tests to set clock in submission service and commented out nilReturn=false declaration scenarios until submission API endpoint is wired up submission service